### PR TITLE
added error handling when building upstart-packages

### DIFF
--- a/debianize.sh
+++ b/debianize.sh
@@ -70,12 +70,12 @@ rm -f *.deb
 
 # build package
 echo "building package"
-$FPM_BIN --maintainer="$MAINTAINER" --exclude=*.pyc --exclude=*.pyo --depends=python --category=python -s python -t deb "$@" setup.py
+$FPM_BIN --maintainer="$MAINTAINER" --exclude=*.pyc --exclude=*.pyo --depends=python --category=python -s python -t deb "$@" ../setup.py
 
 if [ `which dpkg-deb` ]; then
     # only do this if dpkg-deb is installed.
-    PACKAGE_VERSION=`dpkg-deb --info python-*.deb | grep Version | cut -c 11-`
-    PACKAGE_NAME=`dpkg-deb --info python-*.deb | grep Package | cut -c 11-`
+    PACKAGE_VERSION=`dpkg-deb --info *.deb | grep Version | cut -c 11-`
+    PACKAGE_NAME=`dpkg-deb --info *.deb | grep Package | cut -c 11-`
 
     if [ -d upstart ]; then
         echo "building extra package in upstart dir"
@@ -95,10 +95,10 @@ echo "-----------------------------------------------------------"
 echo "Downloading dependencies."
 
 # download dependencies
-HASH=`openssl dgst -sha1 setup.py | cut -c 17-`
+HASH=`openssl dgst -sha1 ../setup.py | cut -c 20-`
 PACKAGE_VAULT=/tmp/.$HASH
 mkdir -p $PACKAGE_VAULT
-$PIP_BIN -q install --upgrade --no-install --build=$PACKAGE_VAULT -e .
+$PIP_BIN -q install --upgrade --no-install --build=$PACKAGE_VAULT -e ../
 
 echo "processing dependencies."
 for NAME in `ls $PACKAGE_VAULT`


### PR DESCRIPTION
Added check, if building the upstart-package was successful. If it was not, abort.
Without that check, it was possible that the subdirectory (etc/init/*) was moved one level up (in case the $PACKAGE_NAME was empty)
